### PR TITLE
Fixed another gappy namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To retrieve the encoded token for transfer, call the `serialize()` method.
 
 ```php
 $algorithm = new Emarref\Jwt\Algorithm\None();
-$encryption = Emarref\Encryption\Factory::create($algorithm);
+$encryption = Emarref\Jwt\Encryption\Factory::create($algorithm);
 $serializedToken = $jwt->serialize($token, $encryption);
 ```
 


### PR DESCRIPTION
There was an another occurrence of the Encryption class usage example, corrected that too.