### PR TITLE
Use timing-safe hash comparision

### DIFF
--- a/src/Encryption/Symmetric.php
+++ b/src/Encryption/Symmetric.php
@@ -56,6 +56,44 @@ class Symmetric extends AbstractEncryption implements EncryptionInterface
      */
     public function verify($value, $signature)
     {
-        return $this->algorithm->compute($value) === $signature;
+        $computedValue = $this->algorithm->compute($value);
+
+        return $this->timingSafeEquals($signature, $computedValue);
+    }
+
+    /**
+     * A timing safe equals comparison.
+     *
+     * @see http://blog.ircmaxell.com/2014/11/its-all-about-time.html
+     *
+     * @param string $safe The internal (safe) value to be checked
+     * @param string $user The user submitted (unsafe) value
+     *
+     * @return boolean True if the two strings are identical.
+     */
+    public function timingSafeEquals($safe, $user)
+    {
+        if (function_exists('hash_equals')) {
+            return hash_equals($user, $safe);
+        }
+
+        $safeLen = strlen($safe);
+        $userLen = strlen($user);
+
+        /*
+         * In general, it's not possible to prevent length leaks. So it's OK to leak the length.
+         * @see http://security.stackexchange.com/questions/49849/timing-safe-string-comparison-avoiding-length-leak
+         */
+        if ($userLen != $safeLen) {
+            return false;
+        }
+
+        $result = 0;
+
+        for ($i = 0; $i < $userLen; $i++) {
+            $result |= (ord($safe[$i]) ^ ord($user[$i]));
+        }
+
+        return $result === 0;
     }
 }


### PR DESCRIPTION
> This branch addresses a timing attack raised by Dennis Detering from [rub.de] when comparing hashes for symmetric encryption verification. Details are below.

## Description

The PHP jwt library by Malcolm Fell version <= 1.0.2 is vulnerable to a timing attack on hash comparison in the symmetric encryption component resulting in crafting a valid signature for arbitrary content.

## Details

The verification of the HMAC hash in the verify() function in [Symmetric.php][1] is vulnerable to a timing attack. No timing safe equal function, like e.g. [hash_equals()][2] (PHP >= 5.6.0 and PHP 7), is used.

This allows an attacker to craft a valid signature for an arbitrary content.

## Recommendation

It is recommended to use a timing safe equal function for comparison. In PHP >= 5.6.0 and PHP 7, the [hash_equals()][2] function has been implemented.

For unsupported versions, the following example function might be used (taken from [here][3] - also recommended for further details of timing attacks on equals comparison):

```php
/**
 * A timing safe equals comparison
 *
 * @param string $safe The internal (safe) value to be checked
 * @param string $user The user submitted (unsafe) value
 *
 * @return boolean True if the two strings are identical.
 */
function timingSafeEquals($safe, $user) {
    $safeLen = strlen($safe);
    $userLen = strlen($user);

    if ($userLen != $safeLen) {
        return false;
    }

    $result = 0;

    for ($i = 0; $i < $userLen; $i++) {
        $result |= (ord($safe[$i]) ^ ord($user[$i]));
    }

    // They are only identical strings if $result is exactly 0...
    return $result === 0;
}
```

[1]: https://github.com/emarref/jwt/blob/master/src/Encryption/Symmetric.php#L59
[2]: http://php.net/manual/de/function.hash-equals.php
[3]: http://blog.ircmaxell.com/2014/11/its-all-about-time.html
