### PR TITLE
Don't escape slashes on serialization

### DIFF
--- a/src/Token/PropertyList.php
+++ b/src/Token/PropertyList.php
@@ -40,7 +40,7 @@ class PropertyList implements \JsonSerializable, \IteratorAggregate
             $properties->$name = $value;
         }
 
-        return json_encode($properties);
+        return json_encode($properties, JSON_UNESCAPED_SLASHES);
     }
 
     /**

--- a/src/Verification/ExpirationVerifier.php
+++ b/src/Verification/ExpirationVerifier.php
@@ -22,8 +22,7 @@ class ExpirationVerifier implements VerifierInterface
             ));
         }
 
-        $expiration = new \DateTime();
-        $expiration->setTimestamp($expirationClaim->getValue());
+        $expiration = \DateTime::createFromFormat('U', $expirationClaim->getValue(), new \DateTimeZone('UTC'));
         return $expiration;
     }
 

--- a/src/Verification/NotBeforeVerifier.php
+++ b/src/Verification/NotBeforeVerifier.php
@@ -27,8 +27,7 @@ class NotBeforeVerifier implements VerifierInterface
         }
 
         if ($now->getTimestamp() < $notBeforeClaim->getValue()) {
-            $notBefore = new \DateTime();
-            $notBefore->setTimestamp($notBeforeClaim->getValue());
+            $notBefore = \DateTime::createFromFormat('U', $notBeforeClaim->getValue(), new \DateTimeZone('UTC'));
             throw new TooEarlyException($notBefore);
         }
     }

--- a/test/Token/PropertyListTest.php
+++ b/test/Token/PropertyListTest.php
@@ -36,7 +36,7 @@ class PropertyListTest extends \PHPUnit_Framework_TestCase
 
     public function testJsonSerialize()
     {
-        $expectedJson = '{"one":"11","two":"2"}';
+        $expectedJson = '{"one":"11","two":"2","url":"https://example.com"}';
 
         $properties = new \ArrayIterator([
             new PropertyStub('one', '1'),
@@ -44,6 +44,7 @@ class PropertyListTest extends \PHPUnit_Framework_TestCase
             new PropertyStub('two', '2'),
             new PropertyStub('three', ''), // Blank value ignored
             new PropertyStub('', '4'),     // Blank name ignored
+            new PropertyStub('url', 'https://example.com'),
         ]);
 
         $this->properties->expects($this->once())


### PR DESCRIPTION
I had a problem with RSA signature validation:
\Emarref\Jwt\Signature\Jws::getUnsignedValue serializes both the header and payload using the PropertyList::jsonSerialize method, and concatenates them with a dot. The encryption verifier uses this value. 
If the payload (or header) contains a slash character in the property value, it gets escaped, because of json_encode's default behavior. For this reason the signature validation always fails.
It usually happens when the property contains an URL.
From PHP 5.4 this behavior can be controlled with the JSON_UNESCAPED_SLASHES option of the json_encode function.

