### PR TITLE
JSON Slashes

### DIFF
--- a/src/Jwt.php
+++ b/src/Jwt.php
@@ -19,9 +19,20 @@ class Jwt
      */
     private $encoder;
 
+    /**
+     * @var Serialization\SerializerInterface
+     */
+    private $serialization;
+
     public function __construct()
     {
         $this->encoder = new Encoding\Base64();
+
+        $this->serialization = new Serialization\Compact(
+            $this->encoder,
+            new HeaderParameter\Factory(),
+            new Claim\Factory()
+        );
     }
 
     /**
@@ -30,13 +41,7 @@ class Jwt
      */
     public function deserialize($jwt)
     {
-        $serialization = new Serialization\Compact(
-            $this->encoder,
-            new HeaderParameter\Factory(),
-            new Claim\Factory()
-        );
-
-        return $serialization->deserialize($jwt);
+        return $this->serialization->deserialize($jwt);
     }
 
     /**
@@ -48,13 +53,7 @@ class Jwt
     {
         $this->sign($token, $encryption);
 
-        $serialization = new Serialization\Compact(
-            $this->encoder,
-            new HeaderParameter\Factory(),
-            new Claim\Factory()
-        );
-
-        return $serialization->serialize($token);
+        return $this->serialization->serialize($token);
     }
 
     /**

--- a/src/Jwt.php
+++ b/src/Jwt.php
@@ -37,11 +37,12 @@ class Jwt
 
     /**
      * @param string $jwt
+     * @param array $tokenOptions
      * @return Token
      */
-    public function deserialize($jwt)
+    public function deserialize($jwt, array $tokenOptions = [])
     {
-        return $this->serialization->deserialize($jwt);
+        return $this->serialization->deserialize($jwt, $tokenOptions);
     }
 
     /**

--- a/src/Serialization/Compact.php
+++ b/src/Serialization/Compact.php
@@ -89,13 +89,12 @@ class Compact implements SerializerInterface
 
     /**
      * @param string $jwt
-     *
+     * @param array $tokenOptions
      * @return Token
-     * @throws \InvalidArgumentException
      */
-    public function deserialize($jwt)
+    public function deserialize($jwt, array $tokenOptions = [])
     {
-        $token = new Token();
+        $token = new Token($tokenOptions);
 
         if (empty($jwt)) {
             throw new \InvalidArgumentException('Not a valid JWT string passed for deserialization');

--- a/src/Serialization/SerializerInterface.php
+++ b/src/Serialization/SerializerInterface.php
@@ -8,9 +8,10 @@ interface SerializerInterface
 {
     /**
      * @param string $jwt
+     * @param array $tokenOptions
      * @return Token
      */
-    public function deserialize($jwt);
+    public function deserialize($jwt, array $tokenOptions = []);
 
     /**
      * @param Token $token

--- a/src/Token.php
+++ b/src/Token.php
@@ -4,11 +4,14 @@ namespace Emarref\Jwt;
 
 use Emarref\Jwt\Claim;
 use Emarref\Jwt\HeaderParameter;
+use Emarref\Jwt\Token\AbstractTokenBody;
 use Emarref\Jwt\Token\Header;
 use Emarref\Jwt\Token\Payload;
 
 class Token
 {
+    const OPT_JSON_ESCAPE_SLASHES = 'json_escape_slashes';
+
     /**
      * @var Header
      */
@@ -24,10 +27,44 @@ class Token
      */
     private $signature;
 
-    public function __construct()
+    /**
+     * @param array $options
+     */
+    public function __construct(array $options = [])
     {
-        $this->header  = new Header();
-        $this->payload = new Payload();
+        $options = $this->parseOptions($options);
+
+        $sectionOptions = [];
+
+        if (false === (bool)$options[self::OPT_JSON_ESCAPE_SLASHES]) {
+            $sectionOptions = [
+                AbstractTokenBody::OPT_JSON_OPTIONS => JSON_UNESCAPED_SLASHES
+            ];
+        }
+
+        $this->header  = new Header($sectionOptions);
+        $this->payload = new Payload($sectionOptions);
+    }
+
+    /**
+     * @param array $options
+     * @return array
+     */
+    protected function parseOptions(array $options)
+    {
+        $defaultOptions = $this->getDefaultOptions();
+
+        return array_merge($defaultOptions, $options);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getDefaultOptions()
+    {
+        return [
+            self::OPT_JSON_ESCAPE_SLASHES => false,
+        ];
     }
 
     /**

--- a/src/Token/AbstractTokenBody.php
+++ b/src/Token/AbstractTokenBody.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Emarref\Jwt\Token;
+
+abstract class AbstractTokenBody implements \JsonSerializable
+{
+    const OPT_JSON_OPTIONS = 'json_options';
+
+    /**
+     * @var PropertyList
+     */
+    protected $propertyList;
+
+    /**
+     * @param array $options
+     */
+    public function __construct(array $options = [])
+    {
+        $options = $this->parseOptions($options);
+
+        $this->propertyList = new PropertyList($options[self::OPT_JSON_OPTIONS]);
+    }
+
+    /**
+     * @param array $options
+     * @return array
+     */
+    protected function parseOptions(array $options)
+    {
+        $defaultOptions = $this->getDefaultOptions();
+
+        return array_merge($defaultOptions, $options);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getDefaultOptions()
+    {
+        return [
+            self::OPT_JSON_OPTIONS => null,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->propertyList->jsonSerialize();
+    }
+}

--- a/src/Token/Header.php
+++ b/src/Token/Header.php
@@ -3,20 +3,9 @@
 namespace Emarref\Jwt\Token;
 
 use Emarref\Jwt\HeaderParameter;
-use Emarref\Jwt\Claim;
 
-class Header implements \JsonSerializable
+class Header extends AbstractTokenBody
 {
-    /**
-     * @var PropertyList
-     */
-    protected $propertyList;
-
-    public function __construct()
-    {
-        $this->propertyList = new PropertyList();
-    }
-
     /**
      * @param HeaderParameter\ParameterInterface $parameter
      * @param boolean                            $critical
@@ -60,13 +49,5 @@ class Header implements \JsonSerializable
     public function getParameters()
     {
         return $this->propertyList;
-    }
-
-    /**
-     * @return string
-     */
-    public function jsonSerialize()
-    {
-        return $this->propertyList->jsonSerialize();
     }
 }

--- a/src/Token/Payload.php
+++ b/src/Token/Payload.php
@@ -4,18 +4,8 @@ namespace Emarref\Jwt\Token;
 
 use Emarref\Jwt\Claim;
 
-class Payload implements \JsonSerializable
+class Payload extends AbstractTokenBody
 {
-    /**
-     * @var PropertyList
-     */
-    protected $propertyList;
-
-    public function __construct()
-    {
-        $this->propertyList = new PropertyList();
-    }
-
     /**
      * @param Claim\ClaimInterface $claim
      */
@@ -46,13 +36,5 @@ class Payload implements \JsonSerializable
     public function getClaims()
     {
         return $this->propertyList;
-    }
-
-    /**
-     * @return string
-     */
-    public function jsonSerialize()
-    {
-        return $this->propertyList->jsonSerialize();
     }
 }

--- a/src/Token/PropertyList.php
+++ b/src/Token/PropertyList.php
@@ -9,9 +9,18 @@ class PropertyList implements \JsonSerializable, \IteratorAggregate
      */
     protected $properties;
 
-    public function __construct()
+    /**
+     * @var int
+     */
+    private $jsonOptions;
+
+    /**
+     * @param int|null $jsonOptions Options to be passed to the json_encode function.
+     */
+    public function __construct($jsonOptions = null)
     {
         $this->properties = new \ArrayObject();
+        $this->jsonOptions = $jsonOptions;
     }
 
     /**
@@ -40,7 +49,7 @@ class PropertyList implements \JsonSerializable, \IteratorAggregate
             $properties->$name = $value;
         }
 
-        return json_encode($properties);
+        return json_encode($properties, $this->jsonOptions);
     }
 
     /**


### PR DESCRIPTION
This branch adds the ability to specify whether or not slashes should be escaped in serialized JSON.

Other libraries ([example 1](https://github.com/namshi/jose/pull/41/files), [example 2](https://github.com/psecio/jwt/commit/1afa9ad6a67ce33b913b6c2101b44c8af2652528), [example 3](https://github.com/tymondesigns/jwt-auth/pull/119/files)) simply ignore slashes. Which means if a third party actor creates a token with escaped slashes, the token verification will fail.

This change achieves two things:
1. Does not escape slashes by default (BC change, reason for major version bump)
2. Allows the developer to manually specify that an individual token should be treated with slashes escaped to enable verification of tokens generated by third party libraries that escape slashes.

``` php
$tokenOptions = [Emarref\Jwt\Token::OPT_JSON_ESCAPE_SLASHES => true];
$token = new Emarref\Jwt\Token($tokenOptions); // Default is false
```
### TODO
- [x] Allow developer to toggle escaped slashes option during verification.
- [ ] Unit tests

A future improvement might add the ability to auto-detect the escaped slashes.
