### PR TITLE
Save the original jwt token body for use in signature verification

### DIFF
--- a/src/Serialization/Compact.php
+++ b/src/Serialization/Compact.php
@@ -103,6 +103,11 @@ class Compact implements SerializerInterface
 
         list($encodedHeader, $encodedPayload, $encodedSignature) = array_pad(explode('.', $jwt, 3), 3, null);
 
+        // Store the encoded unsigned value for verification later. We do this because JSON can change order or spacing and such and
+        // and still have the same value. However, the signature algorithms don't handle that concept. So we keep the original value
+        // to use to verify the signature.
+        $token->setTokenBody($encodedHeader . "." . $encodedPayload);
+
         $decodedHeader    = $this->encoding->decode($encodedHeader);
         $decodedPayload   = $this->encoding->decode($encodedPayload);
         $decodedSignature = $this->encoding->decode($encodedSignature);

--- a/src/Token.php
+++ b/src/Token.php
@@ -24,6 +24,11 @@ class Token
      */
     private $signature;
 
+    /**
+     * @var tokenBody
+     */
+    private $tokenBody;
+
     public function __construct()
     {
         $this->header  = new Header();
@@ -77,5 +82,21 @@ class Token
     public function setSignature($signature)
     {
         $this->signature = $signature;
+    }
+
+    /**
+     * @param string $body
+     */
+    public function setTokenBody($body)
+    {
+       $this->tokenBody = $body;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTokenBody()
+    {
+       return $this->tokenBody;
     }
 }

--- a/src/Verification/EncryptionVerifier.php
+++ b/src/Verification/EncryptionVerifier.php
@@ -58,7 +58,7 @@ class EncryptionVerifier implements VerifierInterface
             ));
         }
 
-        if (!$this->encryption->verify($this->signer->getUnsignedValue($token), $token->getSignature())) {
+        if (!$this->encryption->verify($token->getTokenBody(), $token->getSignature())) {
             throw new InvalidSignatureException;
         }
     }


### PR DESCRIPTION
Based on some of the comments in Issue #22 , I modified Token.php to save the token body and the EncryptionVerifier to validate the signature based on the original token string. 