### PR TITLE
Fix unicode encoding

### DIFF
--- a/src/Token/PropertyList.php
+++ b/src/Token/PropertyList.php
@@ -40,7 +40,7 @@ class PropertyList implements \JsonSerializable, \IteratorAggregate
             $properties->$name = $value;
         }
 
-        return json_encode($properties, JSON_UNESCAPED_UNICODE);
+        return json_encode($properties, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
     }
 
     /**

--- a/src/Token/PropertyList.php
+++ b/src/Token/PropertyList.php
@@ -40,7 +40,7 @@ class PropertyList implements \JsonSerializable, \IteratorAggregate
             $properties->$name = $value;
         }
 
-        return json_encode($properties);
+        return json_encode($properties, JSON_UNESCAPED_UNICODE);
     }
 
     /**

--- a/test/Token/PropertyListTest.php
+++ b/test/Token/PropertyListTest.php
@@ -36,7 +36,7 @@ class PropertyListTest extends \PHPUnit_Framework_TestCase
 
     public function testJsonSerialize()
     {
-        $expectedJson = '{"one":"11","two":"2"}';
+        $expectedJson = '{"one":"11","two":"2","four": "£100"}';
 
         $properties = new \ArrayIterator([
             new PropertyStub('one', '1'),
@@ -44,6 +44,7 @@ class PropertyListTest extends \PHPUnit_Framework_TestCase
             new PropertyStub('two', '2'),
             new PropertyStub('three', ''), // Blank value ignored
             new PropertyStub('', '4'),     // Blank name ignored
+            new PropertyStub('four', '£100'),
         ]);
 
         $this->properties->expects($this->once())


### PR DESCRIPTION
I'm having unicode characters encoded in the JWT token which is sent from a JS implementation. 

The issue with the library:
* decodes the token from base64
* takes the payload and does json_encode on it (which escapes unicode characters into form like \u00e8)
* signs the token with sent signature
* compares to the signed token that was sent - and it doesn’t match becasue the unicode characters where escaped before signing